### PR TITLE
支持windows下取得当前路径

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ var Ksend = require('./ksend');
 var util = require('./util');
 
 var ksend = new Ksend();
-var pwd = process.env.PWD;
+var pwd = process.env.PWD || process.cwd();
 var argv = optimist.argv;
 
 module.exports = function () {


### PR DESCRIPTION
windows环境下没有process.env.PWD这个值，需要用process.cwd()函数返回
